### PR TITLE
Switch to html4 mode

### DIFF
--- a/controllers/router.js
+++ b/controllers/router.js
@@ -3,7 +3,6 @@ angular.module("vibe")
 .config(function($stateProvider, $urlRouterProvider, $locationProvider) {
 
 	$urlRouterProvider.otherwise("/events");
-	$locationProvider.html5Mode(true);
 
 	$stateProvider
 	.state("events", {


### PR DESCRIPTION
As @AkhilHector [suggested](https://github.com/MozillaIndia/vibe/issues/19#issuecomment-131530689) in #19 switching back to html4 solves the issue of us not having server redirects on gh-pages.
